### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 - 👀 I’m interested in computer games.
 - 🌱 I’m currently learning Japanese (and also Git which I actually need to learn so two birds here).
 - 💞️ I’m looking to collaborate on Brutal Alice - The Hundred day's war by working on the English translation.
-- 📫 How to reach me: If you need to, you already know how.  If you're a random person, for now, I might see a post on the Steam dicussion for Brutal Alice.
+- 📫 How to reach me: If you need to, you already know how.  If you're a random person, for now, I might see a post on the Steam discussion for Brutal Alice.
 
 <!---
 JamesTheCheapskate/JamesTheCheapskate is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.


### PR DESCRIPTION
## Summary
- fix small spelling error about Steam discussion link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68460938c9ec832aaa88fbf30cf8ec71